### PR TITLE
Fix pattern which starts with glob issue

### DIFF
--- a/gitignore_test.go
+++ b/gitignore_test.go
@@ -19,11 +19,13 @@ type file struct {
 func TestMatch(t *testing.T) {
 	asserts := []assert{
 		assert{[]string{"a.txt"}, file{"a.txt", false}, true},
+		assert{[]string{"*.txt"}, file{"a.txt", false}, true},
 		assert{[]string{"dir/a.txt"}, file{"dir/a.txt", false}, true},
 		assert{[]string{"dir/*.txt"}, file{"dir/a.txt", false}, true},
 		assert{[]string{"dir2/a.txt"}, file{"dir1/dir2/a.txt", false}, true},
 		assert{[]string{"dir3/a.txt"}, file{"dir1/dir2/dir3/a.txt", false}, true},
 		assert{[]string{"a.txt"}, file{"dir/a.txt", false}, true},
+		assert{[]string{"*.txt"}, file{"dir/a.txt", false}, true},
 		assert{[]string{"a.txt"}, file{"dir1/dir2/a.txt", false}, true},
 		assert{[]string{"dir2/a.txt"}, file{"dir1/dir2/a.txt", false}, true},
 		assert{[]string{"dir"}, file{"dir", true}, true},

--- a/initial_holder.go
+++ b/initial_holder.go
@@ -2,7 +2,7 @@ package gitignore
 
 import "strings"
 
-const initials = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ.*"
+const initials = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ."
 
 type initialPatternHolder struct {
 	patterns      initialPatterns
@@ -26,7 +26,7 @@ func (h *initialPatternHolder) add(pattern string) {
 }
 
 func (h initialPatternHolder) match(path string, isDir bool) bool {
-	if h.patterns.size() == 0 {
+	if h.patterns.size() == 0 && h.otherPatterns.size() == 0 {
 		return false
 	}
 	if patterns, ok := h.patterns.get(path[0]); ok {

--- a/patterns.go
+++ b/patterns.go
@@ -8,6 +8,10 @@ func (ps *patterns) add(pattern pattern) {
 	ps.patterns = append(ps.patterns, pattern)
 }
 
+func (ps *patterns) size() int {
+	return len(ps.patterns)
+}
+
 func (ps patterns) match(path string, isDir bool) bool {
 	for _, p := range ps.patterns {
 		if match := p.match(path, isDir); match {


### PR DESCRIPTION
`*.txt` does not match `a.txt` with original code. Such patterns store in `initialPatternHolder.patterns`(type=`initialPatterns`) but Pattern which starts with `*` should store in `initialPatternHolder.otherPatterns`.

For example a pattern is `*.txt` and an input is `a.txt`, 

https://github.com/syohex/go-gitignore/blob/3d1b725bd7d5c4280673b63385499a6c63c5074c/initial_holder.go#L32

Second return value is false, because `path[0]` is `a` and map has only a `*` key. And there is no other patterns, so `*.txt` does not match `a.txt`.

This is related to https://github.com/monochromegane/the_platinum_searcher/issues/118.