### PR TITLE
Support escaped hash

### DIFF
--- a/gitignore.go
+++ b/gitignore.go
@@ -47,6 +47,9 @@ func NewGitIgnoreFromReader(path string, r io.Reader) gitIgnore {
 		if len(line) == 0 || strings.HasPrefix(line, "#") {
 			continue
 		}
+		if strings.HasPrefix(line, `\#`) {
+			line = strings.TrimPrefix(line, `\`)
+		}
 
 		if strings.HasPrefix(line, "!") {
 			g.acceptPatterns.add(strings.TrimPrefix(line, "!"))

--- a/gitignore_test.go
+++ b/gitignore_test.go
@@ -40,6 +40,7 @@ func TestMatch(t *testing.T) {
 		assert{[]string{"*.txt", "!b.txt"}, file{"dir/b.txt", false}, false},
 		assert{[]string{"dir/*.txt", "!dir/b.txt"}, file{"dir/b.txt", false}, false},
 		assert{[]string{"dir/*.txt", "!/b.txt"}, file{"dir/b.txt", false}, true},
+		assert{[]string{`\#a.txt`}, file{"#a.txt", false}, true},
 	}
 
 	for _, assert := range asserts {


### PR DESCRIPTION
gitignore document says

> A line starting with # serves as a comment. Put a backslash ("\") in front
> of the first hash for patterns that begin with a hash.

This is related to https://github.com/monochromegane/the_platinum_searcher/issues/208