### PR TITLE
Support directory ignores on Windows

### DIFF
--- a/gitignore.go
+++ b/gitignore.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 )
 
@@ -66,9 +65,7 @@ func (g gitIgnore) Match(path string, isDir bool) bool {
 	if err != nil {
 		return false
 	}
-	if runtime.GOOS == "windows" {
-		relativePath = strings.Replace(relativePath, "\\", "/", -1)
-	}
+	relativePath = filepath.ToSlash(relativePath)
 
 	if g.acceptPatterns.match(relativePath, isDir) {
 		return false

--- a/gitignore.go
+++ b/gitignore.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 )
 
@@ -64,6 +65,9 @@ func (g gitIgnore) Match(path string, isDir bool) bool {
 	relativePath, err := filepath.Rel(g.path, path)
 	if err != nil {
 		return false
+	}
+	if runtime.GOOS == "windows" {
+		relativePath = strings.Replace(relativePath, "\\", "/", -1)
 	}
 
 	if g.acceptPatterns.match(relativePath, isDir) {


### PR DESCRIPTION
Current usage of `filepath.Rel` adds backslashes to the path used for matching, breaking directory matching ignores on Windows. This PR adds a check to replace backslashes added by `filepath.Rel` with forward slashes to support matching directories when running on Windows.