### PR TITLE
switch from filepath match to doublestar

### DIFF
--- a/gitignore_test.go
+++ b/gitignore_test.go
@@ -41,6 +41,7 @@ func TestMatch(t *testing.T) {
 		assert{[]string{"dir/*.txt", "!dir/b.txt"}, file{"dir/b.txt", false}, false},
 		assert{[]string{"dir/*.txt", "!/b.txt"}, file{"dir/b.txt", false}, true},
 		assert{[]string{`\#a.txt`}, file{"#a.txt", false}, true},
+		assert{[]string{`**/__test__/**`}, file{"dir1/dir2/__test__/dir3/b.txt", false}, true},
 	}
 
 	for _, assert := range asserts {

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/monochromegane/go-gitignore
+
+go 1.16
+
+require github.com/bmatcuk/doublestar/v4 v4.0.2

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/bmatcuk/doublestar/v4 v4.0.2 h1:X0krlUVAVmtr2cRoTqR8aDMrDqnB36ht8wpWTiQ3jsA=
+github.com/bmatcuk/doublestar/v4 v4.0.2/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=

--- a/match.go
+++ b/match.go
@@ -1,6 +1,8 @@
 package gitignore
 
-import "path/filepath"
+import (
+	ds "github.com/bmatcuk/doublestar/v4"
+)
 
 type pathMatcher interface {
 	match(path string) bool
@@ -19,6 +21,6 @@ type filepathMatcher struct {
 }
 
 func (m filepathMatcher) match(path string) bool {
-	match, _ := filepath.Match(m.path, path)
+	match, _ := ds.Match(m.path, path)
 	return match
 }


### PR DESCRIPTION
This PR uses the `doublestar` library to allow `**` matching for ignores. `doublestar` v4 requires go 1.16 or higher. I also created an initial `go.mod` for the repo.